### PR TITLE
feat: add fullanme override to avoid conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.1]() (2026-04-23)
+
+* Add `name_override` and `fullname_override` to override default one, which cause conflicts while creating multi datadog agent cluster in the same EKS.
+
 ## [0.9.0]() (2025-10-06)
 
 ### ⚠ BREAKING CHANGES

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,12 @@
 locals {
   manifest = <<YAML
 datadog:
+  %{if var.name_override != null}
+  nameOverride: ${var.name_override}
+  %{endif}
+  %{if var.fullname_override != null}
+  fullnameOverride: ${var.fullname_override}
+  %{endif}
   logs:
     enabled: ${var.enabled_logs}
     containerCollectAll: ${var.enabled_container_collect_all_logs}

--- a/variables.tf
+++ b/variables.tf
@@ -120,3 +120,15 @@ variable "container_include" {
   description = "value"
   default     = null
 }
+
+variable "name_override" {
+  type        = string
+  description = "To override the name of the datadog chart"
+  default     = null
+}
+
+variable "fullname_override" {
+  type        = string
+  description = "To override the fullname of the datadog chart"
+  default     = null
+}


### PR DESCRIPTION
## Summary
## [0.9.1]() (2026-04-23)

* Add `name_override` and `fullname_override` to override default one, which cause conflicts while creating multi datadog agent cluster in the same EKS.

<!--- Add some bells and whistles for PR template. --->

### Why
<!--- Clearly define the issue or problem that your changes address. 
Describe what is currently not working as expected or what feature is missing. --->

### What
<!--- Provide a high-level overview of what has been modified, added, or removed in the codebase. 
This could include new features, bug fixes, refactoring efforts, or performance optimizations. --->

### Solution
<!--- Describe the architectural or design decisions you made while implementing the changes.
Explain the thought process behind your approach and how it aligns with best practices or existing patterns in the codebase. --->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
<!--- Please input steps on how to test this PR, including evidence in the form of captured images or videos. If this is not necessary, provide the reason why. --->

## Related Issues
<!--- Add a reference section for management tickets, and relevant conversations. --->
