### PR TITLE
feat: add extra_confd input for cluster-agent custom checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.0]() (2026-05-09)
+
+### Features
+
+* Add `extra_confd` input - inject arbitrary cluster-agent confd files (OpenMetrics, custom tcp_check, etc) without forking the module. Default is `{}` (no-op for existing callers).
+
 ## [0.9.0]() (2025-10-06)
 
 ### ⚠ BREAKING CHANGES

--- a/README.md
+++ b/README.md
@@ -48,9 +48,40 @@ module "datadog" {
 
 ```
 
+### Adding custom cluster-agent checks (extra_confd)
+
+Use `extra_confd` to inject additional cluster-agent confd files without forking the module. This is useful for OpenMetrics, `tcp_check`, and other custom integrations.
+
+```hcl
+module "datadog" {
+  source  = "c0x12c/helm-datadog/aws"
+  version = "~> 0.10.0"
+
+  environment  = var.environment
+  cluster_name = var.cluster_name
+
+  datadog_site    = var.datadog_site
+  datadog_api_key = var.datadog_api_key
+  datadog_app_key = var.datadog_app_key
+
+  extra_confd = {
+    "openmetrics.yaml" = <<-YAML
+      cluster_check: true
+      init_config:
+      instances:
+        - openmetrics_endpoint: https://example.com/metrics
+          namespace: example
+          metrics:
+            - example_metric
+    YAML
+  }
+}
+```
+
 ## Examples
 
 - [Example](./examples/complete/)
+- [Extra confd example](./examples/with-extra-confd/)
 
 <!-- BEGIN_TF_DOCS -->
 
@@ -99,6 +130,7 @@ No modules.
 | <a name="input_enabled_logs"></a> [enabled\_logs](#input\_enabled\_logs)                                                                         | Toggle to enable or disable the logs.            | `bool`                                                                           | `true`      |    no    |
 | <a name="input_enabled_metric_provider"></a> [enabled\_metric\_provider](#input\_enabled\_metric\_provider)                                      | Toggle to enable or disable the metric provider. | `bool`                                                                           | `true`      |    no    |
 | <a name="input_environment"></a> [environment](#input\_environment)                                                                              | Environment where the resources will be created. | `string`                                                                         | n/a         |   yes    |
+| <a name="input_extra_confd"></a> [extra\_confd](#input\_extra\_confd)                                                                            | Additional cluster-agent confd files to inject.  | <pre>map(string)</pre>                                                           | `{}`        |    no    |
 | <a name="input_helm_release_name"></a> [helm\_release\_name](#input\_helm\_release\_name)                                                        | The Helm release of the services.                | `string`                                                                         | `"datadog"` |    no    |
 | <a name="input_http_check_urls"></a> [http\_check\_urls](#input\_http\_check\_urls)                                                              | The list of urls for http check                  | `list(string)`                                                                   | `[]`        |    no    |
 | <a name="input_namespace"></a> [namespace](#input\_namespace)                                                                                    | The Namespace of the services.                   | `string`                                                                         | `"datadog"` |    no    |

--- a/examples/with-extra-confd/README.md
+++ b/examples/with-extra-confd/README.md
@@ -1,0 +1,14 @@
+# Example: extra_confd
+
+This example shows how to inject a custom cluster-agent confd file into the Datadog chart without modifying the module.
+
+The sample uses an OpenMetrics-style config that points at `https://example.com/metrics`.
+
+Use it when you need custom cluster checks such as OpenMetrics or `tcp_check`.
+
+Run the usual Terraform workflow from this directory:
+
+```bash
+terraform init
+terraform plan
+```

--- a/examples/with-extra-confd/main.tf
+++ b/examples/with-extra-confd/main.tf
@@ -1,0 +1,22 @@
+module "datadog" {
+  source = "../.."
+
+  environment  = var.environment
+  cluster_name = var.cluster_name
+
+  datadog_site    = var.datadog_site
+  datadog_api_key = var.datadog_api_key
+  datadog_app_key = var.datadog_app_key
+
+  extra_confd = {
+    "openmetrics.yaml" = <<-YAML
+      cluster_check: true
+      init_config:
+      instances:
+        - openmetrics_endpoint: https://example.com/metrics
+          namespace: example
+          metrics:
+            - example_metric
+    YAML
+  }
+}

--- a/examples/with-extra-confd/variables.tf
+++ b/examples/with-extra-confd/variables.tf
@@ -1,0 +1,24 @@
+variable "environment" {
+  description = "Environment where the resources will be created."
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "The EKS cluster name."
+  type        = string
+}
+
+variable "datadog_api_key" {
+  description = "The datadog api key."
+  type        = string
+}
+
+variable "datadog_app_key" {
+  description = "The datadog app key."
+  type        = string
+}
+
+variable "datadog_site" {
+  description = "The datadog site."
+  type        = string
+}

--- a/examples/with-extra-confd/versions.tf
+++ b/examples/with-extra-confd/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.9.8"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = ">=3.6"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ clusterAgent:
           url: ${url}
           tags:
             - env:${var.environment}
-%{endfor}
+%{endfor}${join("", [for fname, body in var.extra_confd : "\n    ${fname}: |-\n      ${indent(6, body)}"])}
 YAML
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,12 @@ variable "http_check_urls" {
   default     = []
 }
 
+variable "extra_confd" {
+  description = "Additional cluster-agent confd files to inject. Map of filename -> YAML body (rendered as-is under datadog.clusterAgent.confd). Example: { \"clickpipes.yaml\" = \"cluster_check: true\\ninit_config:\\ninstances:\\n  - openmetrics_endpoint: ...\" }"
+  type        = map(string)
+  default     = {}
+}
+
 variable "timeout" {
   description = "Default timeout of datadog"
   default     = 1200


### PR DESCRIPTION
## Summary

Adds a new `extra_confd` input (`map(string)`, default `{}`) that injects arbitrary confd files under `datadog.clusterAgent.confd`. Backward compatible — empty default is a no-op for all existing callers.

Motivation: 8fleet needs to scrape ClickHouse Cloud's Prometheus endpoint for ClickPipes state monitoring via an OpenMetrics V2 cluster check. Currently the module hardcodes `http_check.yaml` only and exposes no extension hook, forcing a fork or a downstream override file.

## Changes

- `variables.tf` — new `extra_confd` input
- `main.tf` — extend the `confd:` heredoc to render each map entry under `clusterAgent.confd`
- `README.md` — usage example + new example link
- `CHANGELOG.md` — v0.10.0 entry
- `examples/with-extra-confd/` — minimal OpenMetrics example

## Verification

- `terraform fmt -recursive -check` clean
- `terraform validate` on `examples/with-extra-confd` passes
- Render-tested both branches:
  - `extra_confd = {}` → manifest byte-identical to v0.9.0 (no extra stanza)
  - `extra_confd = { "clickpipes.yaml" = "..." }` → renders as a separate `clickpipes.yaml: |-` block under `clusterAgent.confd` with correct 4/6-space indentation, multi-line bodies preserved

## Release

Tag `v0.10.0` (additive feature, backward compatible).

## Test plan

- [ ] CI / pre-commit clean
- [ ] Reviewer confirms heredoc indentation under `clusterAgent.confd`
- [ ] Reviewer confirms `examples/with-extra-confd` matches `examples/complete` style