### PR TITLE
feat: add portEnabled for DD trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+## [0.11.0]() (2026-06-10)
+
+### Features
+
+* Enable APM hostPort (`datadog.apm.portEnabled`) by default so applications can send traces to the DaemonSet agent via `DD_AGENT_HOST=status.hostIP`.
+
+### Inputs
+
+* Add `enabled_apm_port` (default `true`).
+
 ## [0.10.0](https://github.com/c0x12c/terraform-modules-registry/compare/terraform-aws-helm-datadog/v0.9.0...terraform-aws-helm-datadog/v0.10.0) (2026-06-07)
 
 

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,8 @@ nameOverride: ${var.name_override}
 fullnameOverride: ${var.fullname_override}
 %{endif}
 datadog:
+  apm:
+    portEnabled: ${var.enabled_apm_port}
   logs:
     enabled: ${var.enabled_logs}
     containerCollectAll: ${var.enabled_container_collect_all_logs}

--- a/variables.tf
+++ b/variables.tf
@@ -58,6 +58,12 @@ variable "chart_version" {
   description = "The version of the datadog chart"
 }
 
+variable "enabled_apm_port" {
+  type        = bool
+  default     = true
+  description = "Expose APM trace port 8126 on the node via hostPort so apps can reach the DaemonSet agent using DD_AGENT_HOST=status.hostIP."
+}
+
 variable "datadog_envs" {
   description = "Environment variables for datadog agents"
   type = list(object({


### PR DESCRIPTION
## [0.11.0]() (2026-06-10)

### Features

* Enable APM hostPort (`datadog.apm.portEnabled`) by default so applications can send traces to the DaemonSet agent via `DD_AGENT_HOST=status.hostIP`.

### Inputs

* Add `enabled_apm_port` (default `true`).